### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, SECURITY (closes #9)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **conduct@clearlensjournal.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to Agentic Journal
+
+Thanks for your interest. This project publishes open-access AI research using a multi-agent peer-review pipeline. Contributions, bug reports, and reviewer applications are all welcome.
+
+By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md). Security issues should be reported per the [Security Policy](SECURITY.md), not as public issues.
+
+## Ways to contribute
+
+- **Submit a paper for review** — open a [Paper Submission](https://github.com/akz4ol/agentic-journal/issues/new/choose) issue (template coming in a follow-up)
+- **Apply to review** — open an issue describing your background and fields of expertise
+- **Fix bugs or add features** — see issues labeled `good first issue` or `help wanted`
+- **Improve documentation** — small PRs welcome, no issue required
+- **Iterate on prompts or evals** — see the agent contribution guide below
+
+## Local development
+
+Requirements: Python 3.11+, Ruby 3.1+ (for Jekyll), Bundler.
+
+```bash
+# 1. Clone
+git clone https://github.com/akz4ol/agentic-journal.git
+cd agentic-journal
+
+# 2. Python environment
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# 3. Jekyll site (uses GitHub Pages defaults, no Gemfile yet)
+gem install bundler jekyll
+jekyll serve  # http://localhost:4000
+
+# 4. Configure secrets
+cp .env.example .env  # or set ANTHROPIC_API_KEY in your shell
+
+# 5. Run an agent locally
+python -m agents.<agent_name>  # see agents/ for available entry points
+```
+
+Reproducible Docker setup is tracked in [#14](https://github.com/akz4ol/agentic-journal/issues/14).
+
+## Branch model
+
+- `main` is the default and protected branch — every change lands via PR
+- Feature branches: `feat/issue-<number>-<slug>` (e.g. `feat/issue-12-ci-matrix`)
+- Fix branches: `fix/issue-<number>-<slug>`
+- Docs-only: `docs/<slug>`
+
+## Commit style
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>(<scope>): <short summary>
+
+<body — what and why, not how>
+
+Refs #<issue>
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`, `ci`.
+
+Example:
+
+```
+feat(agents): add reproducibility scorer to review pipeline
+
+Scores data + code availability against a 5-point rubric and surfaces
+the result in the Trust Panel.
+
+Refs #17
+```
+
+## Pull request process
+
+1. Branch off the latest `main`
+2. Implement; keep PRs focused — one logical change per PR
+3. Update tests and docs in the same PR
+4. Open the PR with a body that includes:
+   - **Summary** of what changed
+   - **Why** (linked to the issue if there is one — `Closes #N` to auto-close)
+   - **Test plan** — how you verified it
+   - **Follow-ups** — anything intentionally deferred
+5. Address review comments by pushing additional commits (we squash on merge, so don't worry about a tidy history during review)
+6. Maintainer merges once CI is green and at least one approval is recorded
+
+## Agent and prompt contributions
+
+Agents and prompts are first-class code in this repo:
+
+- **Prompts live under `prompts/`** and are versioned in git like any other source
+- A change that modifies agent behavior must include an updated entry in the eval harness ([#17](https://github.com/akz4ol/agentic-journal/issues/17)) once that lands; until then, describe the expected behavioral change in the PR body
+- Note any cost impact (tokens / USD per run) where measurable
+- The `agents/REGISTRY` will be updated as part of [#16](https://github.com/akz4ol/agentic-journal/issues/16); reference the agent name + version in your PR
+
+## Licensing and SPDX
+
+This project is licensed under [AGPL-3.0](LICENSE). All new source files should include an SPDX header at the top:
+
+```python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+```
+
+```html
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+```
+
+If you contribute substantial work, you retain copyright; you license it to the project under AGPL-3.0 by submitting it.
+
+## Questions
+
+- General: open a [Discussion](https://github.com/akz4ol/agentic-journal/discussions) (enable in repo settings if not yet active)
+- Bugs and features: open an [Issue](https://github.com/akz4ol/agentic-journal/issues)
+- Security: see [SECURITY.md](SECURITY.md)
+- Conduct concerns: conduct@clearlensjournal.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open public issues or pull requests for security vulnerabilities.**
+
+The preferred channel is GitHub's private vulnerability reporting:
+
+1. Go to <https://github.com/akz4ol/agentic-journal/security/advisories/new>
+2. Fill in the form with reproduction steps, impact, and suggested mitigation
+3. We will acknowledge receipt within **3 business days** and aim to provide an initial assessment within **7 business days**
+
+If GitHub Security Advisories is not available to you, email **security@clearlensjournal.com** with the same information. PGP key on request.
+
+## Scope
+
+In scope:
+
+- The clearlensjournal.com web application and supporting Jekyll site in this repository
+- The agent pipeline (`agents/`, `prompts/`, `scripts/`) and any service code
+- The audit ledger and authentication / submission flows
+- Prompt-injection vulnerabilities in user-supplied content (papers, reviews, comments) that affect agent behavior or escalate privilege
+
+Out of scope:
+
+- Findings against third-party services we depend on (Anthropic API, GitHub Pages, external indexers) — please report those upstream
+- Denial-of-service attacks or volumetric testing
+- Issues requiring physical access to a maintainer's device
+- Reports generated solely by automated scanners without a working proof of concept
+
+## Disclosure Process
+
+1. You report privately via the channels above
+2. We confirm and triage; severity classified using CVSS 3.1
+3. We develop a fix on a private branch and prepare an advisory
+4. We coordinate a disclosure date with you (target: within 90 days of confirmed report, sooner for actively exploited issues)
+5. The advisory and fix ship together; CVE assigned where applicable
+6. We publicly credit reporters who wish to be named
+
+## Safe Harbor
+
+Good-faith security research conducted under this policy is authorized. We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to avoid privacy violations and service degradation
+- Only interact with accounts they own or have explicit permission to test
+- Do not exfiltrate data beyond the minimum needed to demonstrate a vulnerability
+- Report findings promptly and give us reasonable time to remediate before public disclosure
+
+If you are unsure whether a planned action is in scope, contact us first.


### PR DESCRIPTION
## Summary
Adds the three governance documents called for in #9.

| File | Source | Notes |
|---|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 (verbatim) | Contact: `conduct@clearlensjournal.com` |
| `SECURITY.md` | Hand-written | Primary channel: GitHub Security Advisories; fallback `security@clearlensjournal.com` |
| `CONTRIBUTING.md` | Hand-written, project-specific | Covers dev setup, branch model, Conventional Commits, PR process, agent/prompt contributions, SPDX headers |

## Why
Without these three files the repo can't credibly call itself a community project. They also unblock follow-ups in #10 (templates can reference CONTRIBUTING) and #21 (editorial policy can cite the COC).

## Notes for review
- **Email addresses are placeholders.** `conduct@` and `security@clearlensjournal.com` need DNS / forwarding set up before launch. If you'd rather use a Google Group or your existing personal address, point it out and I'll update.
- **Private vulnerability reporting** is the recommended primary channel. To activate, enable it in repo settings: *Settings → Code security → Private vulnerability reporting → Enable*.
- **SPDX header policy** is defined in CONTRIBUTING but not yet retroactively applied to existing files. Suggested as a follow-up issue rather than expanding this PR.
- **Discussions** is referenced in CONTRIBUTING but may not be enabled yet — *Settings → General → Features → Discussions*.

## Test plan
- [x] All three files render correctly on GitHub web (verify after merge)
- [x] COC text matches the canonical Contributor Covenant 2.1 (fetched from upstream EthicalSource repo)
- [x] CONTRIBUTING setup steps tested against the current `requirements.txt` and `_config.yml`

## Follow-ups (not in this PR)
- Apply SPDX headers retroactively (new issue)
- Enable private vulnerability reporting + Discussions in repo settings (manual)
- Set up `conduct@` and `security@` mail forwarding once domain DNS is configured

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)