### PR TITLE
chore: add issue + PR templates and CODEOWNERS (closes #10)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Code owners for agentic-journal
+# Each line: <pattern>  <owner>...
+# The last matching pattern wins.
+#
+# When more maintainers join, add them here. Teams (e.g. @org/editorial)
+# are preferred over individual users for areas with multiple owners.
+
+# Default owner — every change requires review by a maintainer
+*                              @akz4ol
+
+# Agent and prompt changes — quality-sensitive, separate review
+/agents/                       @akz4ol
+/prompts/                      @akz4ol
+/scripts/                      @akz4ol
+
+# Editorial / governance content — wording matters
+/CODE_OF_CONDUCT.md            @akz4ol
+/CONTRIBUTING.md               @akz4ol
+/SECURITY.md                   @akz4ol
+/LICENSE                       @akz4ol
+
+# CI and infra — guardrails for everyone else
+/.github/                      @akz4ol
+/.github/workflows/            @akz4ol

--- a/.github/ISSUE_TEMPLATE/agent_eval_regression.yml
+++ b/.github/ISSUE_TEMPLATE/agent_eval_regression.yml
@@ -1,0 +1,91 @@
+name: 🤖 Agent eval regression
+description: Report a regression in agent or prompt behavior caught by evals or observed in production
+title: "[Eval Regression] <agent>: <symptom>"
+labels: [agent, bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when an agent's behavior has demonstrably worsened — review quality, citation accuracy, factuality, tone, cost, or latency.
+
+  - type: input
+    id: agent
+    attributes:
+      label: Agent name
+      description: From the agent registry (see #16) — e.g. `reviewer-v2`, `qc-second-pass`.
+      placeholder: reviewer-v2
+    validations:
+      required: true
+
+  - type: input
+    id: prompt_version
+    attributes:
+      label: Prompt version / commit
+      description: Path under `prompts/` and the git SHA where the regression was observed.
+      placeholder: prompts/reviewer.md @ a1b2c3d
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      placeholder: claude-opus-4-7 / claude-sonnet-4-6 / etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Observed regression
+      description: What changed? Score delta if available.
+      placeholder: Citation-accuracy score dropped from 0.92 → 0.78 on the AI/ML golden set after merging #123.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: How to reproduce — eval command or production run ID.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Artifacts
+      description: Audit-ledger entries, eval output, sample inputs/outputs (links or pasted with sensitive data redacted).
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical — papers actively reviewed with broken agent
+        - High — regression on golden set above threshold
+        - Medium — small but real quality drop
+        - Low — flake / borderline
+    validations:
+      required: true
+
+  - type: input
+    id: cost_delta
+    attributes:
+      label: Cost / latency impact (if any)
+      placeholder: +35% tokens per run, +12s p50 latency
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: gates
+    attributes:
+      label: Gates
+      options:
+        - label: I've checked this isn't already tracked
+          required: true
+        - label: I've linked the offending PR or prompt change above (if known)
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: 🐛 Bug report
+description: Report a defect in the site, agent pipeline, or workflows
+title: "[Bug] <short description>"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections below so we can reproduce and fix it.
+
+        **Security issues**: do not file here — see [SECURITY.md](https://github.com/akz4ol/agentic-journal/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug.
+      placeholder: When I click "Submit", the form silently fails and no issue is created.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps from a known starting state.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Site (Jekyll / public pages)
+        - Submission portal
+        - Agent pipeline (review, scoring, QC)
+        - GitHub Actions workflow
+        - Documentation
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: paper_or_run_id
+    attributes:
+      label: Paper or run ID (if applicable)
+      placeholder: e.g. AJ-2026-MJVL4YC8 or workflow run URL
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser + OS for site bugs; Python version + OS for pipeline bugs.
+      placeholder: |
+        - Browser: Firefox 132 on macOS 14.5
+        - or: Python 3.11.7, Ubuntu 22.04
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or workflow output
+      description: Paste relevant log lines, error messages, or attach screenshots. Redact anything sensitive.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: prereqs
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: This is not a security vulnerability (those go to SECURITY.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📄 Submit a paper for review
+    url: https://clearlensjournal.com/portal/
+    about: Paper submissions go through the journal portal, not GitHub issues. The portal handles PDF upload, metadata, and ID assignment automatically.
+  - name: 💬 Ask a question or start a discussion
+    url: https://github.com/akz4ol/agentic-journal/discussions
+    about: For open-ended questions, ideas, or community discussion. Please use Discussions instead of opening an issue.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/akz4ol/agentic-journal/security/advisories/new
+    about: Security issues must be reported privately. Please do not open a public issue.
+  - name: ⚖️ Code of Conduct concern
+    url: mailto:conduct@clearlensjournal.com
+    about: Report a code-of-conduct violation privately to the maintainers.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,69 @@
+name: ✨ Feature request
+description: Suggest a new capability or improvement
+title: "[Feature] <short description>"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Please describe the problem first, the proposed solution second.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What's the situation today? Who is affected? Why does it matter?
+      placeholder: Reviewers can't tell which agent version produced a critique, so it's hard to track regressions over time.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should change? Concrete is better than abstract.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you weighed and rejected, and why.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      options:
+        - Site / public pages
+        - Submission portal
+        - Agent pipeline (review, scoring, QC)
+        - Audit ledger / transparency
+        - Editorial / governance
+        - Marketing / outreach
+        - Infrastructure / CI
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: success
+    attributes:
+      label: How would we know it worked?
+      description: One or two measurable acceptance criteria.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: prereqs
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: I'm willing to discuss tradeoffs before any work starts
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+
+## Summary
+<!-- 1–3 bullets on what changed. Focus on *why*, not a diff readout. -->
+-
+
+## Linked issue
+<!-- Use "Closes #N" to auto-close on merge, or "Refs #N" for partial work. -->
+Closes #
+
+## Changes
+<!-- Optional: brief breakdown of files / areas touched if non-obvious. -->
+
+## Test plan
+<!-- How did you verify this? Be specific. -->
+- [ ]
+- [ ]
+
+## Screenshots / recordings
+<!-- For UI changes. Delete if not applicable. -->
+
+## Agent / prompt changes
+<!-- Required if this PR touches agents/, prompts/, or scripts/ that affect agent behavior. -->
+- [ ] Not applicable
+- [ ] Updated agent registry entry (`agents/REGISTRY*`)
+- [ ] Bumped prompt version + noted expected behavioral change
+- [ ] Ran the eval harness; results: <link or "no regression">
+- [ ] Cost delta (tokens / USD per run): <e.g. ±5%>
+
+## Checklist
+- [ ] Branch named `feat/issue-N-slug`, `fix/issue-N-slug`, or `docs/<slug>`
+- [ ] Conventional Commit message
+- [ ] Tests added or updated where applicable
+- [ ] Docs updated where applicable (README, CONTRIBUTING, in-code docs)
+- [ ] No secrets or credentials committed
+- [ ] New source files include the SPDX header (see CONTRIBUTING.md)
+
+## Follow-ups intentionally deferred
+<!-- Anything you noticed but didn't fix here. Link to existing issues or call out new ones to file. -->
+-


### PR DESCRIPTION
## Summary
- 3 issue forms (bug, feature, agent eval regression) + chooser config
- 1 PR template with agent/prompt-aware checklist
- CODEOWNERS with `@akz4ol` as default + per-area rules

## Linked issue
Closes #10

## Key decisions
- **No \`paper_submission.yml\` template.** The existing automated portal (`process-submission.yml` + `scripts/validate_submission.py`) generates structured submission issues with the `submission` label. A human-typed template would conflict and cause downstream pipeline failures. The chooser config instead routes "Submit a paper" out to https://clearlensjournal.com/portal/.
- **Blank issues disabled.** All paths require either a template or a contact link, which keeps inbound triage clean.
- **Agent-eval-regression form** captures the fields needed once #16 (agent registry) and #17 (eval harness) land — agent name, prompt version + git SHA, model, severity, cost delta.

## Files
- \`.github/ISSUE_TEMPLATE/config.yml\`
- \`.github/ISSUE_TEMPLATE/bug_report.yml\`
- \`.github/ISSUE_TEMPLATE/feature_request.yml\`
- \`.github/ISSUE_TEMPLATE/agent_eval_regression.yml\`
- \`.github/PULL_REQUEST_TEMPLATE.md\`
- \`.github/CODEOWNERS\`

## Test plan
- [x] All 4 YAMLs parse with PyYAML locally
- [ ] After merge: open *New Issue* on the repo and confirm the chooser shows three templates + four contact links in the right order
- [ ] After merge: open a draft PR and confirm the template populates
- [ ] After merge: confirm CODEOWNERS triggers automatic review request on a test PR

## Follow-ups (not in this PR)
- Enable Discussions in repo settings (referenced in chooser)
- Enable Private Vulnerability Reporting in repo settings (referenced in chooser)
- Once #16 lands, link agent-eval template to the registry path
- Once teams form (e.g. \`@akz4ol/editorial\`), update CODEOWNERS to use teams instead of a single user

🤖 Generated with [Claude Code](https://claude.com/claude-code)